### PR TITLE
Add Swift video converter macOS app and CLI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "VideoConverter",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "VideoConverterApp", targets: ["VideoConverterApp"]),
+        .executable(name: "VideoConverterCLI", targets: ["VideoConverterCLI"]),
+        .library(name: "VideoConverterCore", targets: ["VideoConverterCore"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "VideoConverterCore",
+            path: "Sources/VideoConverterCore"
+        ),
+        .executableTarget(
+            name: "VideoConverterApp",
+            dependencies: ["VideoConverterCore"],
+            path: "Sources/VideoConverterApp",
+            resources: [
+                .process("Resources")
+            ],
+            swiftSettings: [
+                .define("APP_TARGET")
+            ]
+        ),
+        .executableTarget(
+            name: "VideoConverterCLI",
+            dependencies: ["VideoConverterCore"],
+            path: "Sources/VideoConverterCLI"
+        )
+    ]
+)

--- a/QuickActions/README.md
+++ b/QuickActions/README.md
@@ -1,0 +1,31 @@
+# Finder Quick Action Templates
+
+The Swift package includes a command-line converter (`VideoConverterCLI`) so you can create Finder Quick Actions for right-click conversions.
+
+## Sample Shell Script
+
+After you build the CLI target (`swift build -c release --product VideoConverterCLI`), the binary will be created inside `.build/release/VideoConverterCLI`. The following shell script wraps it with some simple logging and Finder notifications:
+
+```bash
+#!/bin/bash
+
+set -euo pipefail
+
+CLI_PATH="$HOME/Developer/VideoConverter/.build/release/VideoConverterCLI"
+FORMAT="mp4"
+
+for file in "$@"; do
+  "$CLI_PATH" --format "$FORMAT" "$file"
+done
+```
+
+You can save this as `~/Library/Application Support/VideoConverter/convert-mp4.sh` and mark it executable (`chmod +x`).
+
+## Creating the Quick Action
+
+1. Open **Shortcuts** or **Automator** and create a new **Quick Action**.
+2. Configure it to receive files or folders in Finder.
+3. Add a **Run Shell Script** step and paste the script above. Update `CLI_PATH` to the absolute path of your built CLI binary.
+4. Save the Quick Action as "Convert MOV to MP4" (or any name you prefer).
+
+The new action appears in Finder's context menu under **Quick Actions**. Because it invokes the shared CLI, it uses the same conversion presets as the GUI app.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# VideoConverter
+
+A lightweight SwiftUI macOS application that uses AVFoundation to batch convert `.mov` videos into `.mp4`, `.m4v`, or `.mov` containers. The project also ships with a command-line companion so you can wire the converter into Finder Quick Actions for right-click conversions.
+
+## Features
+
+- Drag and drop videos from Finder onto the app window for instant conversion.
+- Pick files using an `NSOpenPanel` if you prefer browsing.
+- Choose between MP4 (H.264), M4V, QuickTime passthrough, or HEVC output.
+- Monitor conversion progress for each file, including completion timestamps and destination links.
+- Command line tool (`VideoConverterCLI`) for automation and Finder integration.
+
+## Requirements
+
+- macOS 13 Ventura or later.
+- Xcode 15 or later to build the Swift Package as an app bundle.
+
+## Building the macOS App
+
+1. Open the project in Xcode:
+   ```bash
+   open Package.swift
+   ```
+2. When Xcode finishes resolving the package graph, select the **VideoConverterApp** scheme and the **My Mac** destination.
+3. Build & run (`⌘R`). Xcode will create an `.app` bundle inside the Derived Data folder that you can keep in `/Applications`.
+
+### Using the App
+
+- Drag `.mov` files from Finder onto the drop zone to begin conversion.
+- Use the toolbar button or the `Convert > Select Files…` menu to open files.
+- The output files are written alongside the source videos. The destination column includes a clickable link to reveal the file in Finder.
+
+## Finder Quick Action (Right-Click Conversion)
+
+You can reuse the command-line target to create a Quick Action that appears in Finder's context menu. After building the `VideoConverterCLI` target, follow these steps:
+
+1. Locate the CLI binary in Xcode's Derived Data folder. A quick way to retrieve the path is to run:
+   ```bash
+   swift build -c release --product VideoConverterCLI
+   swift build -c release --show-bin-path
+   ```
+   The CLI executable will live inside the printed `.build/release` directory.
+2. Open the **Shortcuts** app (or Automator if you prefer classic Quick Actions) and create a new **Quick Action**.
+3. Configure it to receive files in Finder, then add a **Run Shell Script** action:
+   ```bash
+   /path/to/VideoConverterCLI --format mp4 "$@"
+   ```
+4. Save the Quick Action (for example, "Convert MOV to MP4"). It will immediately appear under Finder's right-click menu (`Quick Actions` submenu).
+
+Because the CLI shares the same conversion core as the app, you get identical presets and export logic. You can also duplicate the Quick Action for different output formats by changing the `--format` flag.
+
+## Drag & Drop Integration
+
+The SwiftUI interface registers a drop target for `public.file-url` items, so you can drag one or many files directly from Finder. The ViewModel resolves security-scoped URLs, kicks off the conversion workflow on the main actor, and updates the table with live progress values using async/await.
+
+## Testing Without macOS
+
+The repository is designed for macOS and relies on AVFoundation and SwiftUI. Those frameworks are unavailable in this Linux-based environment, so automated tests are not included. Build and test the package on a Mac.
+
+## Repository Layout
+
+```
+├── Package.swift
+├── README.md
+├── Sources
+│   ├── VideoConverterApp
+│   │   ├── ContentView.swift
+│   │   ├── ConverterViewModel.swift
+│   │   ├── Resources
+│   │   │   └── Assets.xcassets
+│   │   └── main.swift
+│   ├── VideoConverterCLI
+│   │   └── main.swift
+│   └── VideoConverterCore
+│       ├── VideoConversionError.swift
+│       ├── VideoConversionService.swift
+│       └── VideoFormat.swift
+└── QuickActions
+    └── README.md (instructions for manual Quick Action setup)
+```
+
+## License
+
+MIT

--- a/Sources/VideoConverterApp/ContentView.swift
+++ b/Sources/VideoConverterApp/ContentView.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import VideoConverterCore
+
+struct ContentView: View {
+    @EnvironmentObject private var viewModel: ConverterViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            header
+            DropTargetView()
+            conversionList
+        }
+        .padding()
+        .frame(minWidth: 600, minHeight: 420)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button(action: viewModel.pickFilesAndConvert) {
+                    Label("Select Files", systemImage: "folder")
+                }
+                .disabled(viewModel.isProcessing)
+            }
+        }
+        .alert("Conversion Failed", isPresented: Binding(get: {
+            viewModel.lastError != nil
+        }, set: { isPresented in
+            if !isPresented {
+                viewModel.lastError = nil
+            }
+        })) {
+            Button("OK", role: .cancel) { viewModel.lastError = nil }
+        } message: {
+            Text(viewModel.lastError ?? "")
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Video Converter")
+                .font(.largeTitle)
+                .bold()
+            Text("Drop .mov files below or pick them from Finder. They will be exported using AVFoundation so you don't need third-party codecs.")
+                .foregroundColor(.secondary)
+            HStack {
+                Text("Output format:")
+                Picker("Output format", selection: $viewModel.selectedFormat) {
+                    ForEach(VideoFormat.allCases) { format in
+                        Text(format.displayName).tag(format)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+        }
+    }
+
+    private var conversionList: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if viewModel.conversions.isEmpty {
+                Text("Conversions will appear here with progress and destination paths.")
+                    .foregroundColor(.secondary)
+            } else {
+                Table(viewModel.conversions) {
+                    TableColumn("Source") { item in
+                        Text(item.sourceURL.lastPathComponent)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    TableColumn("Status") { item in
+                        statusView(for: item)
+                    }
+                    TableColumn("Destination") { item in
+                        if let destination = item.destinationURL {
+                            Link(destination.lastPathComponent, destination: destination)
+                        } else if item.state == .running {
+                            ProgressView(value: item.progress)
+                                .frame(width: 120)
+                        } else {
+                            Text(item.errorDescription ?? "")
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .frame(maxHeight: .infinity)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func statusView(for item: ConversionSummary) -> some View {
+        switch item.state {
+        case .pending:
+            Label("Pending", systemImage: "clock")
+        case .running:
+            HStack {
+                ProgressView(value: item.progress)
+                Text("\(Int(item.progress * 100))%")
+            }
+        case .succeeded:
+            Label("Complete", systemImage: "checkmark.circle.fill")
+                .foregroundColor(.green)
+        case .failed:
+            Label("Failed", systemImage: "xmark.octagon.fill")
+                .foregroundColor(.red)
+        }
+    }
+}
+
+private struct DropTargetView: View {
+    @EnvironmentObject private var viewModel: ConverterViewModel
+    @State private var isTargeted = false
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(isTargeted ? Color.accentColor : Color.secondary, style: StrokeStyle(lineWidth: 2, dash: [6]))
+                .background(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(isTargeted ? Color.accentColor.opacity(0.1) : Color.clear)
+                )
+            VStack(spacing: 12) {
+                Image(systemName: "film")
+                    .font(.system(size: 48))
+                Text("Drop video files here")
+                    .font(.title3)
+                Text("You can drag files directly from Finder. Multiple files are supported.")
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(32)
+        }
+        .frame(maxWidth: .infinity, minHeight: 180)
+        .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .onDrop(of: [UTType.fileURL.identifier], isTargeted: $isTargeted) { providers in
+            viewModel.handleDroppedItems(providers)
+            return true
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(ConverterViewModel())
+}

--- a/Sources/VideoConverterApp/ConverterViewModel.swift
+++ b/Sources/VideoConverterApp/ConverterViewModel.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Combine
+import AppKit
+import VideoConverterCore
+
+@MainActor
+final class ConverterViewModel: ObservableObject {
+    @Published var conversions: [ConversionSummary] = []
+    @Published var selectedFormat: VideoFormat = .mp4
+    @Published var isProcessing: Bool = false
+    @Published var lastError: String?
+
+    private let service = VideoConversionService()
+
+    func handleDroppedItems(_ providers: [NSItemProvider]) {
+        Task {
+            let urls = await extractFileURLs(from: providers)
+            await convert(urls: urls)
+        }
+    }
+
+    func pickFilesAndConvert() {
+        let panel = NSOpenPanel()
+        panel.allowedFileTypes = ["mov", "mp4", "m4v"]
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+
+        panel.begin { [weak self] response in
+            guard response == .OK, let self else { return }
+            Task { await self.convert(urls: panel.urls) }
+        }
+    }
+
+    func convert(urls: [URL]) async {
+        guard !urls.isEmpty else { return }
+        isProcessing = true
+        defer { isProcessing = false }
+
+        for url in urls {
+            var summary = ConversionSummary(sourceURL: url, format: selectedFormat)
+            summary.state = .running
+            summary.startedAt = Date()
+            conversions.insert(summary, at: 0)
+
+            do {
+                let destination = try await service.convert(fileAt: url, to: selectedFormat) { [weak self] progress in
+                    Task { @MainActor in
+                        guard let index = self?.conversions.firstIndex(where: { $0.id == summary.id }) else { return }
+                        self?.conversions[index].progress = progress
+                    }
+                }
+                if let index = conversions.firstIndex(where: { $0.id == summary.id }) {
+                    conversions[index].destinationURL = destination
+                    conversions[index].finishedAt = Date()
+                    conversions[index].progress = 1
+                    conversions[index].state = .succeeded
+                }
+            } catch {
+                if let index = conversions.firstIndex(where: { $0.id == summary.id }) {
+                    conversions[index].finishedAt = Date()
+                    conversions[index].state = .failed
+                    conversions[index].errorDescription = error.localizedDescription
+                }
+                lastError = error.localizedDescription
+            }
+        }
+    }
+
+    private func extractFileURLs(from providers: [NSItemProvider]) async -> [URL] {
+        await withTaskGroup(of: URL?.self) { group in
+            var urls: [URL] = []
+            for provider in providers where provider.hasItemConformingToTypeIdentifier("public.file-url") {
+                group.addTask {
+                    await withCheckedContinuation { continuation in
+                        provider.loadItem(forTypeIdentifier: "public.file-url", options: nil) { item, error in
+                            if let url = item as? URL {
+                                continuation.resume(returning: url)
+                            } else if
+                                let data = item as? Data,
+                                let string = String(data: data, encoding: .utf8),
+                                let url = URL(string: string)
+                            {
+                                continuation.resume(returning: url)
+                            } else {
+                                continuation.resume(returning: nil)
+                            }
+                        }
+                    }
+                }
+            }
+
+            for await url in group {
+                if let url {
+                    urls.append(url)
+                }
+            }
+
+            return urls
+        }
+    }
+}

--- a/Sources/VideoConverterApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Sources/VideoConverterApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/VideoConverterApp/Resources/Assets.xcassets/Contents.json
+++ b/Sources/VideoConverterApp/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/VideoConverterApp/main.swift
+++ b/Sources/VideoConverterApp/main.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+@main
+struct VideoConverterApp: App {
+    @StateObject private var viewModel = ConverterViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(viewModel)
+        }
+        .commands {
+            CommandMenu("Convert") {
+                Button("Select Files…") {
+                    viewModel.pickFilesAndConvert()
+                }
+                .disabled(viewModel.isProcessing)
+            }
+        }
+    }
+}

--- a/Sources/VideoConverterCLI/main.swift
+++ b/Sources/VideoConverterCLI/main.swift
@@ -1,0 +1,70 @@
+import Foundation
+import VideoConverterCore
+
+enum CLIError: Error, LocalizedError {
+    case missingInput
+
+    var errorDescription: String? {
+        switch self {
+        case .missingInput:
+            return "You must pass at least one input file (.mov) to convert."
+        }
+    }
+}
+
+@main
+struct VideoConverterCLI {
+    static func main() async {
+        do {
+            let (format, inputPaths) = try parseArguments()
+            guard !inputPaths.isEmpty else {
+                throw CLIError.missingInput
+            }
+
+            let service = VideoConversionService()
+            for path in inputPaths {
+                let url = URL(fileURLWithPath: path)
+                do {
+                    let destination = try await service.convert(fileAt: url, to: format, destinationFolder: nil) { progress in
+                        let percentage = Int(progress * 100)
+                        FileHandle.standardError.write("Converting \(url.lastPathComponent): \(percentage)%\n".data(using: .utf8)!)
+                    }
+                    print(destination.path)
+                } catch {
+                    FileHandle.standardError.write("Failed to convert \(url.path): \(error.localizedDescription)\n".data(using: .utf8)!)
+                }
+            }
+        } catch {
+            fputs("Error: \(error.localizedDescription)\n", stderr)
+            exit(EXIT_FAILURE)
+        }
+    }
+
+    private static func parseArguments() throws -> (VideoFormat, [String]) {
+        var args = CommandLine.arguments.dropFirst()
+        var format: VideoFormat = .mp4
+        var paths: [String] = []
+
+        while let arg = args.first {
+            args = args.dropFirst()
+            if arg == "--format", let value = args.first {
+                args = args.dropFirst()
+                if let parsedFormat = VideoFormat(rawValue: value) {
+                    format = parsedFormat
+                } else {
+                    throw NSError(
+                        domain: "VideoConverterCLI",
+                        code: 0,
+                        userInfo: [
+                            NSLocalizedDescriptionKey: "Unknown format \(value). Available: \(VideoFormat.allCases.map(\.rawValue).joined(separator: ", "))"
+                        ]
+                    )
+                }
+            } else {
+                paths.append(arg)
+            }
+        }
+
+        return (format, paths)
+    }
+}

--- a/Sources/VideoConverterCore/VideoConversionError.swift
+++ b/Sources/VideoConverterCore/VideoConversionError.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public enum VideoConversionError: Error, LocalizedError {
+    case exportSessionCreationFailed
+    case exportFailed(Error?)
+    case exportCancelled
+    case fileAlreadyExists(URL)
+
+    public var errorDescription: String? {
+        switch self {
+        case .exportSessionCreationFailed:
+            return "Failed to create an export session for the selected file."
+        case .exportFailed(let error):
+            if let error {
+                return "Conversion failed: \(error.localizedDescription)"
+            }
+            return "Conversion failed for an unknown reason."
+        case .exportCancelled:
+            return "The conversion was cancelled."
+        case .fileAlreadyExists(let url):
+            return "The destination file already exists at \(url.path)."
+        }
+    }
+}

--- a/Sources/VideoConverterCore/VideoConversionService.swift
+++ b/Sources/VideoConverterCore/VideoConversionService.swift
@@ -1,0 +1,102 @@
+import Foundation
+import AVFoundation
+
+public struct ConversionSummary: Identifiable, Hashable, Codable {
+    public enum State: String, Codable {
+        case pending
+        case running
+        case succeeded
+        case failed
+    }
+
+    public let id: UUID
+    public let sourceURL: URL
+    public var destinationURL: URL?
+    public var format: VideoFormat
+    public var startedAt: Date?
+    public var finishedAt: Date?
+    public var progress: Double
+    public var state: State
+    public var errorDescription: String?
+
+    public init(id: UUID = UUID(), sourceURL: URL, format: VideoFormat) {
+        self.id = id
+        self.sourceURL = sourceURL
+        self.format = format
+        self.progress = 0
+        self.state = .pending
+    }
+}
+
+public actor VideoConversionService {
+    public init() {}
+
+    public func convert(
+        fileAt url: URL,
+        to format: VideoFormat,
+        destinationFolder: URL? = nil,
+        progressHandler: @escaping (Double) -> Void
+    ) async throws -> URL {
+        let asset = AVAsset(url: url)
+        guard let exportSession = AVAssetExportSession(asset: asset, presetName: format.exportPreset) else {
+            throw VideoConversionError.exportSessionCreationFailed
+        }
+
+        let outputDirectory = destinationFolder ?? url.deletingLastPathComponent()
+        let baseFilename = url.deletingPathExtension().lastPathComponent
+        let destinationURL = uniqueDestinationURL(
+            directory: outputDirectory,
+            baseName: baseFilename,
+            fileExtension: format.fileExtension
+        )
+
+        if FileManager.default.fileExists(atPath: destinationURL.path) {
+            throw VideoConversionError.fileAlreadyExists(destinationURL)
+        }
+
+        exportSession.outputURL = destinationURL
+        if format == .mp4 {
+            exportSession.outputFileType = .mp4
+        } else if format == .m4v {
+            exportSession.outputFileType = .m4v
+        } else {
+            exportSession.outputFileType = .mov
+        }
+        exportSession.shouldOptimizeForNetworkUse = true
+
+        try await withCheckedThrowingContinuation { continuation in
+            exportSession.exportAsynchronously {
+                switch exportSession.status {
+                case .completed:
+                    continuation.resume(returning: destinationURL)
+                case .failed:
+                    continuation.resume(throwing: VideoConversionError.exportFailed(exportSession.error))
+                case .cancelled:
+                    continuation.resume(throwing: VideoConversionError.exportCancelled)
+                default:
+                    continuation.resume(throwing: VideoConversionError.exportFailed(exportSession.error))
+                }
+            }
+
+            Task.detached { [weak exportSession] in
+                while let exportSession, exportSession.status == .exporting {
+                    progressHandler(Double(exportSession.progress))
+                    try? await Task.sleep(nanoseconds: 200_000_000)
+                }
+            }
+        }
+
+        return destinationURL
+    }
+
+    private func uniqueDestinationURL(directory: URL, baseName: String, fileExtension: String) -> URL {
+        var candidate = directory.appendingPathComponent("\(baseName).\(fileExtension)")
+        var suffix = 1
+        let fileManager = FileManager.default
+        while fileManager.fileExists(atPath: candidate.path) {
+            candidate = directory.appendingPathComponent("\(baseName)-\(suffix).\(fileExtension)")
+            suffix += 1
+        }
+        return candidate
+    }
+}

--- a/Sources/VideoConverterCore/VideoFormat.swift
+++ b/Sources/VideoConverterCore/VideoFormat.swift
@@ -1,0 +1,52 @@
+import Foundation
+import AVFoundation
+
+public enum VideoFormat: String, CaseIterable, Identifiable, Codable {
+    case mp4
+    case mov
+    case m4v
+    case presetHEVC
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .mp4:
+            return "H.264 (.mp4)"
+        case .mov:
+            return "QuickTime (.mov)"
+        case .m4v:
+            return "H.264 (.m4v)"
+        case .presetHEVC:
+            return "HEVC (.mov)"
+        }
+    }
+
+    public var fileExtension: String {
+        switch self {
+        case .mp4:
+            return "mp4"
+        case .mov, .presetHEVC:
+            return "mov"
+        case .m4v:
+            return "m4v"
+        }
+    }
+
+    public var exportPreset: String {
+        switch self {
+        case .mp4:
+            return AVAssetExportPresetHighestQuality
+        case .mov:
+            return AVAssetExportPresetPassthrough
+        case .m4v:
+            return AVAssetExportPreset1920x1080
+        case .presetHEVC:
+            if #available(macOS 11.0, *) {
+                return AVAssetExportPresetHEVCHighestQuality
+            } else {
+                return AVAssetExportPresetHighestQuality
+            }
+        }
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -1,2 +1,0 @@
-testing first
-


### PR DESCRIPTION
## Summary
- add a SwiftUI-based macOS app with drag-and-drop conversion workflow
- build a shared AVFoundation conversion core reused by a CLI companion target
- document Finder Quick Action setup for right-click conversions

## Testing
- not run (macOS-only components)

------
https://chatgpt.com/codex/tasks/task_e_68e5623b234c8323b742e10185e5aa0b